### PR TITLE
Corrections to ISO xpaths

### DIFF
--- a/src/checks/entity.format.nonproprietary.xml
+++ b/src/checks/entity.format.nonproprietary.xml
@@ -118,8 +118,6 @@ def call():
       <xpath>
           /*/distributionInfo/MD_Distribution/distributionFormat/MD_Format/name/*/text()[normalize-space()] |
           /*/distributionInfo/MD_Distribution/distributor/MD_Distributor/distributorFormat/MD_Format/name/*/text()[normalize-space()] |
-          /*/identificationInfo/MD_DataIdentification/resourceFormat/MD_Format/formatSpecificationCitation/CI_Citation/identifier/MD_Identifier/code |
-          /*/identificationInfo/MD_DataIdentification/resourceFormat/MD_Format/formatSpecificationCitation/CI_Citation/title | 
           /DryadDataFile/format/CharacterString |
           //resourceFormat/MD_Format/name | 
           /eml/dataset/*/physical/dataFormat/externallyDefinedFormat/formatName/text()[normalize-space()] |

--- a/src/checks/entity.format.present.xml
+++ b/src/checks/entity.format.present.xml
@@ -40,7 +40,6 @@ def call():
       <xpath>
           /*/distributionInfo/MD_Distribution/distributionFormat/MD_Format |
           /*/distributionInfo/MD_Distribution/distributor/MD_Distributor/distributorFormat/MD_Format |
-          /*/identificationInfo/MD_DataIdentification/resourceFormat/MD_Format |
           /DryadDataFile/format |
           //resourceFormat/MD_Format | 
           /eml/dataset/*/physical/dataFormat |

--- a/src/checks/entity.identifier.present.xml
+++ b/src/checks/entity.identifier.present.xml
@@ -48,8 +48,6 @@ def call():
    <selector>
       <name>entityIdentifier</name>
       <xpath>
-          /*/identificationInfo/*/citation/CI_Citation/identifier/MD_Identifier/code//text()[normalize-space()] |
-          /*/identificationInfo/*/citation/CI_Citation/identifier/RS_Identifier/code//text()[normalize-space()] |
           /*/identifier |
           /eml/dataset/*/alternateIdentifier |
           /eml/dataset/*[self::dataTable|self::spatialRaster|self::spatialVector|self::storedProcedure|self::view|self::otherEntity]/@id |

--- a/src/checks/entity.identifier.resolvable.xml
+++ b/src/checks/entity.identifier.resolvable.xml
@@ -83,8 +83,6 @@ def call():
    <selector>
       <name>entityIdentifier</name>
       <xpath>
-          /*/identificationInfo/*/citation/CI_Citation/identifier/MD_Identifier/code//text()[normalize-space()] |
-          /*/identificationInfo/*/citation/CI_Citation/identifier/RS_Identifier/code//text()[normalize-space()] |
           /*/identifier |
           /eml/dataset/*[self::dataTable|self::spatialRaster|self::spatialVector|self::storedProcedure|self::view|self::otherEntity]/@id |
           /eml/dataset/*/alternateIdentifier |

--- a/src/checks/entity.identifierType.present.xml
+++ b/src/checks/entity.identifierType.present.xml
@@ -39,8 +39,6 @@ def call():
    <selector>
       <name>entityIdentifierType</name>
       <xpath>/resource/identifier/@identifierType |
-         /*/identificationInfo/*/citation/CI_Citation/identifier/MD_Identifier/codeSpace//text()[normalize-space()] |
-         /*/identificationInfo/*/citation/CI_Citation/identifier/MD_Identifier/authority//text()[normalize-space()] |
          /eml/dataset/*[self::dataTable|self::spatialRaster|self::spatialVector|self::storedProcedure|self::view|self::otherEntity]/@system |
          /eml/dataset/*/alternateIdentifier/@system 
       </xpath>

--- a/src/checks/entity.name.present.xml
+++ b/src/checks/entity.name.present.xml
@@ -62,15 +62,12 @@ def call():
    <selector>
       <name>entities</name>
       <xpath>
-          /eml/dataset/*[self::dataTable|self::spatialRaster|self::spatialVector|self::storedProcedure|self::view|self::otherEntity] |
-          /*/contentInfo/MD_CoverageDescription |
-          /*/contentInfo/MI_CoverageDescription
+          /eml/dataset/*[self::dataTable|self::spatialRaster|self::spatialVector|self::storedProcedure|self::view|self::otherEntity]
       </xpath>
       <subSelector>
          <name>name</name>
          <xpath>
-             ./entityName |
-             ./attributeDescription/RecordType
+             ./entityName 
          </xpath>
      </subSelector>
    </selector>

--- a/src/checks/entity.type.present.xml
+++ b/src/checks/entity.type.present.xml
@@ -30,9 +30,7 @@ def call():
    <selector>
       <name>entityTypePresent</name>
       <xpath>boolean(
-         /*/metadataScope/MD_MetadataScope/resourceScope/MD_ScopeCode or
          /*/type or
-         /*/hierarchyLevel/MD_ScopeCode or
          /eml/dataset/dataTable or
          /eml/dataset/otherEntity or
          /eml/dataset/spatialVector or

--- a/src/checks/resource.abstractLength.xml
+++ b/src/checks/resource.abstractLength.xml
@@ -53,7 +53,7 @@ def call():
           /*/description//text()[normalize-space()] |
           /eml/*/abstract//text()[normalize-space()] |
           /*/identificationInfo/*/abstract//text()[normalize-space()] |
-          /*/identificationInfo/*/abstrac//text()[normalize-space()]
+          /*/identificationInfo/*/abstract//text()[normalize-space()]
       </xpath>
    </selector>
    <dialect>


### PR DESCRIPTION
Primarily this set of changes removes xpaths that reference resource level information within entity checks. See issue #400 