### PR TITLE
Feature-469: Data Check Markdown Formatting Part 2

### DIFF
--- a/src/checks/data.character-encoding.xml
+++ b/src/checks/data.character-encoding.xml
@@ -36,8 +36,8 @@ def call():
 
         # If data object is not available, skip the pid.
         try:
-          obj, sys = manager.get_object(pid)
-          fname = md.read_sysmeta_element(sys, "fileName")
+            obj, sys = manager.get_object(pid)
+            fname = md.read_sysmeta_element(sys, "fileName")
         except Exception as e:
             output_data.append(f"Unexpected Exception: {e}")
             output_type.append("text")
@@ -50,18 +50,18 @@ def call():
         # TODO: Discuss whether we should also look for characters that can cause
         #       parsing concerns like \n, \t and add a warning
         if enc_type == "ascii":
-            output_data.append(f"{fname} is a valid 'ascii' document and does not contain encoding errors.")
-            output_type.append("text")
+            output_data.append(f"`{fname}` is a valid 'ascii' document and does not contain encoding errors.")
+            output_type.append("markdown")
             status_data.append("SUCCESS")
         elif enc_type == "utf-8":
-            output_data.append(f"{fname} is a valid 'utf-8' document and does not contain encoding errors.")
-            output_type.append("text")
+            output_data.append(f"`{fname}` is a valid 'utf-8' document and does not contain encoding errors.")
+            output_type.append("markdown")
             status_data.append("SUCCESS")
         else:
             # TODO: For now, we will only accept valid 'utf-8' and 'ascii' documents as a SUCCESS
             #       Discuss if we should have specific standards, or should proceed in another path
-            output_data.append(f"{fname} has been detected as a '{enc_type}' document, and may contain errors: {msg}.")
-            output_type.append("text")
+            output_data.append(f"`{fname}` has been detected as a '{enc_type}' document, and may contain errors: {msg}.")
+            output_type.append("markdown")
             status_data.append("FAILURE")
 
     successes = sum(x == "SUCCESS" for x in status_data)

--- a/src/checks/data.format.congruent.xml
+++ b/src/checks/data.format.congruent.xml
@@ -79,19 +79,19 @@ def call():
       df_new = d1_formats[(d1_formats["media_type"] == mime_type) & (d1_formats["extension"] == ext)]
 
       if df_new.shape[0] == 0:
-        output_data.append(f"{fname} does not have a formatId matching its media type and extension.")
-        output_type.append("text")
+        output_data.append(f"`{fname}` does not have a formatId matching its media type and extension.")
+        output_type.append("markdown")
         status_data.append("FAILURE")
         continue
       
       if fid in df_new["format_id"].values:
-        output_data.append(f"{fname}'s formatId matches its media type and extension.")
-        output_type.append("text")
+        output_data.append(f"`{fname}`'s formatId matches its media type and extension.")
+        output_type.append("markdown")
         status_data.append("SUCCESS")
         continue
       else:
-        output_data.append(f"{fname}'s formatId does not match its media type and extension.")
-        output_type.append("text")
+        output_data.append(f"`{fname}`'s formatId does not match its media type and extension.")
+        output_type.append("markdown")
         status_data.append("FAILURE")
 
   successes = sum(x == "SUCCESS" for x in status_data)

--- a/src/checks/data.table-text-delimited.glimpse.xml
+++ b/src/checks/data.table-text-delimited.glimpse.xml
@@ -38,14 +38,14 @@ def call():
 
         # If data object is not available, skip the pid.
         try:
-          # if file is not text/csv, skip it
-          # otherwise get the object and filename
-          obj, fname, csv_status = md.get_valid_csv(manager, pid)
-          if csv_status == "SKIP":
-              output_data.append(f"{fname} is not a text-delimited table, skipping.")
-              output_type.append("text")
-              status_data.append(csv_status)
-              continue
+            # if file is not text/csv, skip it
+            # otherwise get the object and filename
+            obj, fname, csv_status = md.get_valid_csv(manager, pid)
+            if csv_status == "SKIP":
+                output_data.append(f"`{fname}` is not a text-delimited table, skipping.")
+                output_type.append("markdown")
+                status_data.append(csv_status)
+                continue
         except Exception as e:
             output_data.append(f"Unexpected Exception: {e}")
             output_type.append("text")
@@ -55,8 +55,8 @@ def call():
         # Ensure that the data object is documented in the list of entity names
         entity_index = md.find_entity_index(fname, pid, entityNames, ids)[0]
         if entity_index is None:
-            output_data.append(f"{fname} does not appear to be documented in the metadata.")
-            output_type.append("text")
+            output_data.append(f"`{fname}` does not appear to be documented in the metadata.")
+            output_type.append("markdown")
             status_data.append("FAILURE")
             continue
 
@@ -79,8 +79,8 @@ def call():
         d_read_decoded = obj_bytes_read.decode(encoding_type)
         df, error = md.read_csv_with_metadata(d_read_decoded, fieldDelimiter[entity_index], num_header_lines, encoding_type)
         if error:
-            output_data.append(f"{fname} is unable to be read as a table. {error}")
-            output_type.append("text")
+            output_data.append(f"`{fname}` is unable to be read as a table. {error}")
+            output_type.append("markdown")
             status_data.append("FAILURE")
             continue
 
@@ -92,7 +92,7 @@ def call():
             status_data.append("SUCCESS")
         else:
             output_data.append(f"`{fname}` cannot be parsed." + char(type(df)))
-            output_type.append("text")
+            output_type.append("markdown")
             status_data.append("FAILURE")
 
     successes = sum(x == "SUCCESS" for x in status_data)

--- a/src/checks/data.table-text-delimited.glimpse.xml
+++ b/src/checks/data.table-text-delimited.glimpse.xml
@@ -87,11 +87,11 @@ def call():
         if isinstance(df, pd.DataFrame):
             summary = df.describe()
             summary_md = summary.to_markdown()
-            output_data.append(f"**{fname}** \n {summary_md} \n")
+            output_data.append(f"**`{fname}`** \n {summary_md} \n")
             output_type.append("markdown")
             status_data.append("SUCCESS")
         else:
-            output_data.append(f"{fname} cannot be parsed." + char(type(df)))
+            output_data.append(f"`{fname}` cannot be parsed." + char(type(df)))
             output_type.append("text")
             status_data.append("FAILURE")
 

--- a/src/checks/data.table-text-delimited.normalized.xml
+++ b/src/checks/data.table-text-delimited.normalized.xml
@@ -38,25 +38,25 @@ def call():
 
         # If data object is not available, skip the pid.
         try:
-          # if file is not text/csv, skip it
-          # otherwise get the object and filename
-          obj, fname, csv_status = md.get_valid_csv(manager, pid)
-          if csv_status == "SKIP":
-              output_data.append(f"{fname} is not a text-delimited table, skipping.")
-              output_type.append("text")
-              status_data.append(csv_status)
-              continue
+            # if file is not text/csv, skip it
+            # otherwise get the object and filename
+            obj, fname, csv_status = md.get_valid_csv(manager, pid)
+            if csv_status == "SKIP":
+                output_data.append(f"`{fname}` is not a text-delimited table, skipping.")
+                output_type.append("markdown")
+                status_data.append(csv_status)
+                continue
         except Exception as e:
             output_data.append(f"Unexpected Exception: {e}")
-            output_type.append("text")
+            output_type.append("markdown")
             status_data.append("FAILURE")
             continue
 
         # Ensure that the data object is documented in the list of entity names
         entity_index = md.find_entity_index(fname, pid, entityNames, ids)[0]
         if entity_index is None:
-            output_data.append(f"{fname} does not appear to be documented in the metadata.")
-            output_type.append("text")
+            output_data.append(f"`{fname}` does not appear to be documented in the metadata.")
+            output_type.append("markdown")
             status_data.append("FAILURE")
             continue
 
@@ -79,8 +79,8 @@ def call():
         d_read_decoded = obj_bytes_read.decode(encoding_type)
         df, error = md.read_csv_with_metadata(d_read_decoded, fieldDelimiter[entity_index], num_header_lines, encoding_type)
         if error:
-            output_data.append(f"{fname} is unable to be read as a table. {error}")
-            output_type.append("text")
+            output_data.append(f"`{fname}`is unable to be read as a table. {error}")
+            output_type.append("markdown")
             status_data.append("FAILURE")
             continue
 
@@ -92,10 +92,10 @@ def call():
         duplicate_cols, contains_period = md.find_duplicate_column_names(df)
         if duplicate_cols:
             normalization_errors_count += 1
-            normalization_errors_data.append(f"{fname} contains duplicate columns: {', '.join(duplicate_cols)}")
+            normalization_errors_data.append(f"`{fname}` contains duplicate columns: {', '.join(duplicate_cols)}")
         elif contains_period:
             # Add a warning if there's no duplicates and a period is found in the field
-            warn_msg = f"{fname} has periods '.' in the field names. We recommend replacing with underscores '_'"
+            warn_msg = f"`{fname}` has periods '.' in the field names. We recommend replacing with underscores '_'"
             normalization_errors_data.append(warn_msg)
 
         # Check for duplicate column content
@@ -107,7 +107,7 @@ def call():
                 for dup, orig, h in duplicate_col_content
             )
             normalization_errors_data.append(
-                f"{fname} contains duplicate column content: {error_msg}"
+                f"`{fname}` contains duplicate column content: {error_msg}"
             )
 
         # Check for duplicate rows
@@ -116,7 +116,7 @@ def call():
             dr_summary = duplicate_rows.to_markdown()
             normalization_errors_count += 1
             normalization_errors_data.append(
-                f"{fname} contains duplicate rows: \n{dr_summary} \n"
+                f"`{fname}` contains duplicate rows: \n{dr_summary} \n"
             )
 
         # Check for obscene amount of columns
@@ -124,7 +124,7 @@ def call():
         if num_of_cols >= 1000:
             normalization_errors_count += 1
             normalization_errors_data.append(
-                f"{fname} contains an excessive number of columns: {num_of_cols}"
+                f"`{fname}` contains an excessive number of columns: {num_of_cols}"
             )
 
         # TODO: DISCUSS - Adding check for reasonable amount of non-repeating values

--- a/src/checks/data.table-text-delimited.normalized.xml
+++ b/src/checks/data.table-text-delimited.normalized.xml
@@ -132,13 +132,13 @@ def call():
         norm_errors_md_output = '\n'.join(f'| {line}' for line in normalization_errors_data)
         if normalization_errors_count == 0:
             if normalization_errors_data:
-                output_data.append(f"{fname} is normalized. Additional Details: {norm_errors_md_output}")
+                output_data.append(f"`{fname}` is normalized. Additional Details: {norm_errors_md_output}")
             else:
-                output_data.append(f"{fname} is normalized.")
+                output_data.append(f"`{fname}` is normalized.")
             output_type.append("markdown")
             status_data.append("SUCCESS")
         else:
-            output_data.append(f"{fname} contains normalization issues: {norm_errors_md_output}")
+            output_data.append(f"`{fname}` contains normalization issues: {norm_errors_md_output}")
             output_type.append("markdown")
             status_data.append("FAILURE")
 

--- a/src/checks/data.table-text-delimited.variables-congruent.xml
+++ b/src/checks/data.table-text-delimited.variables-congruent.xml
@@ -38,14 +38,14 @@ def call():
 
         # If data object is not available, skip the pid.
         try:
-          # if file is not text/csv, skip it
-          # otherwise get the object and filename
-          obj, fname, csv_status = md.get_valid_csv(manager, pid)
-          if csv_status == "SKIP":
-              output_data.append(f"{fname} is not a text-delimited table, skipping.")
-              output_type.append("text")
-              status_data.append(csv_status)
-              continue
+            # if file is not text/csv, skip it
+            # otherwise get the object and filename
+            obj, fname, csv_status = md.get_valid_csv(manager, pid)
+            if csv_status == "SKIP":
+                output_data.append(f"`{fname}` is not a text-delimited table, skipping.")
+                output_type.append("markdown")
+                status_data.append(csv_status)
+                continue
         except Exception as e:
             output_data.append(f"Unexpected Exception: {e}")
             output_type.append("text")
@@ -55,8 +55,8 @@ def call():
         # Ensure that the data object is documented in the list of entity names
         entity_index = md.find_entity_index(fname, pid, entityNames, ids)[0]
         if entity_index is None:
-            output_data.append(f"{fname} does not appear to be documented in the metadata.")
-            output_type.append("text")
+            output_data.append(f"`{fname}` does not appear to be documented in the metadata.")
+            output_type.append("markdown")
             status_data.append("FAILURE")
             continue
 
@@ -79,8 +79,8 @@ def call():
         d_read_decoded = obj_bytes_read.decode(encoding_type)
         df, error = md.read_csv_with_metadata(d_read_decoded, fieldDelimiter[entity_index], num_header_lines, encoding_type)
         if error:
-            output_data.append(f"{fname} is unable to be read as a table: {error}.")
-            output_type.append("text")
+            output_data.append(f"`{fname}` is unable to be read as a table: {error}.")
+            output_type.append("markdown")
             status_data.append("FAILURE")
             continue
 
@@ -94,8 +94,8 @@ def call():
             status_data.append("FAILURE")
         # Check if column names match documentation
         if att_names == col_names:
-            output_data.append(f"{fname} variable names match documentation.")
-            output_type.append("text")
+            output_data.append(f"`{fname}` variable names match documentation.")
+            output_type.append("markdown")
             status_data.append("SUCCESS")
         else:
             # Create a table to assist with comparing the variable names

--- a/src/checks/data.table-text-delimited.variables-congruent.xml
+++ b/src/checks/data.table-text-delimited.variables-congruent.xml
@@ -118,7 +118,7 @@ def call():
             row_list = [header, separator] + rows
             table_rows = "\n".join(row_list)
             # table_rows = "\n".join([header, separator] + rows)
-            output_data.append(f"{fname} variable names do not match documentation.\n{table_rows}")
+            output_data.append(f"`{fname}` variable names do not match documentation.\n{table_rows}")
             output_type.append("markdown")
             status_data.append("FAILURE")
 

--- a/src/checks/data.table-text-delimited.well-formed.xml
+++ b/src/checks/data.table-text-delimited.well-formed.xml
@@ -38,14 +38,14 @@ def call():
 
         # If data object is not available, skip the pid.
         try:
-          # if file is not text/csv, skip it
-          # otherwise get the object and filename
-          obj, fname, csv_status = md.get_valid_csv(manager, pid)
-          if csv_status == "SKIP":
-              output_data.append(f"{fname} is not a text-delimited table, skipping.")
-              output_type.append("text")
-              status_data.append(csv_status)
-              continue
+            # if file is not text/csv, skip it
+            # otherwise get the object and filename
+            obj, fname, csv_status = md.get_valid_csv(manager, pid)
+            if csv_status == "SKIP":
+                output_data.append(f"`{fname}` is not a text-delimited table, skipping.")
+                output_type.append("markdown")
+                status_data.append(csv_status)
+                continue
         except Exception as e:
             output_data.append(f"Unexpected Exception: {e}")
             output_type.append("text")
@@ -55,8 +55,8 @@ def call():
         # Ensure that the data object is documented in the list of entity names
         entity_index = md.find_entity_index(fname, pid, entityNames, ids)[0]
         if entity_index is None:
-            output_data.append(f"{fname} does not appear to be documented in the metadata.")
-            output_type.append("text")
+            output_data.append(f"`{fname}` does not appear to be documented in the metadata.")
+            output_type.append("markdown")
             status_data.append("FAILURE")
             continue
 
@@ -80,18 +80,18 @@ def call():
             d_read_decoded = obj_bytes_read.decode(encoding_type)
             df, error = md.read_csv_with_metadata(d_read_decoded, fieldDelimiter[entity_index], num_header_lines, encoding_type)
         except Exception as e:
-            output_data.append(f"{fname} is unable to be read as a table.")
-            output_type.append("text")
+            output_data.append(f"`{fname}` is unable to be read as a table.")
+            output_type.append("markdown")
             status_data.append("FAILURE")
             continue
             
         if isinstance(df, pd.DataFrame):
-            output_data.append(f"{fname} is able to be parsed.")
-            output_type.append("text")
+            output_data.append(f"`{fname}` is able to be parsed.")
+            output_type.append("markdown")
             status_data.append("SUCCESS")
         else:
-            output_data.append(f"{fname} cannot be parsed because it is of type {type(df).__name__}, not a dataframe.")
-            output_type.append("text")
+            output_data.append(f"`{fname}` cannot be parsed because it is of type {type(df).__name__}, not a dataframe.")
+            output_type.append("markdown")
             status_data.append("FAILURE")
 
     successes = sum(x == "SUCCESS" for x in status_data)


### PR DESCRIPTION
**Summary of Changes:**
- Change all data check outputs where a file name is involved to be of type `markdown` and wrap file names in backticks